### PR TITLE
Native filter returns the number of bits set to 1.

### DIFF
--- a/ext/cbloomfilter/cbloomfilter.c
+++ b/ext/cbloomfilter/cbloomfilter.c
@@ -176,6 +176,18 @@ static VALUE bf_num_set(VALUE self) {
     return INT2FIX(bf->num_set);
 }
 
+static VALUE bf_num_bit(VALUE self){
+    struct BloomFilter *bf;
+    int i,j,count = 0;
+    Data_Get_Struct(self, struct BloomFilter, bf);
+    for (i = 0; i < bf->bytes; i++) {
+        for (j = 0; j < 8; j++) {
+            count += (bf->ptr[i] >> j) & 1;
+        }
+    }
+    return INT2FIX(count);
+}
+
 static VALUE bf_insert(VALUE self, VALUE key) {
     VALUE skey;
     int index, seed;
@@ -341,6 +353,7 @@ void Init_cbloomfilter(void) {
     rb_define_method(cBloomFilter, "b", bf_b, 0);
     rb_define_method(cBloomFilter, "r", bf_r, 0);
     rb_define_method(cBloomFilter, "num_set", bf_num_set, 0);
+    rb_define_method(cBloomFilter, "num_bit", bf_num_bit, 0);
     rb_define_method(cBloomFilter, "insert", bf_insert, 1);
     rb_define_method(cBloomFilter, "delete", bf_delete, 1);
     rb_define_method(cBloomFilter, "include?", bf_include, -1);

--- a/lib/bloomfilter/native.rb
+++ b/lib/bloomfilter/native.rb
@@ -36,6 +36,11 @@ module BloomFilter
     def size; @bf.num_set; end
     def merge!(o); @bf.merge!(o.bf); end
 
+    # Returns the number of bits that are set to 1 in the filter.
+    def bits_count
+      @bf.num_bit
+    end
+
     def bitmap
       @bf.bitmap
     end

--- a/spec/native_spec.rb
+++ b/spec/native_spec.rb
@@ -42,6 +42,16 @@ describe BloomFilter::Native do
       bf.include?("abcd").should be_false
       bf.include?("test", "test1", '12345').should be_true
     end
+
+    it "should return the number of bits set to 1" do
+      bf = Native.new(:hashes => 4)
+      bf.insert("test")
+      bf.bits_count.should == 4
+
+      bf = Native.new(:hashes => 1)
+      bf.insert("test")
+      bf.bits_count.should == 1
+    end
   end
 
   context "behave like counting bloom filter" do


### PR DESCRIPTION
This is a tiny feature, but very useful with union and intersection - it allows for estimating the size of union and intersection sets.
