### PR TITLE
Solving UTF8 issue on save

### DIFF
--- a/lib/bloomfilter/native.rb
+++ b/lib/bloomfilter/native.rb
@@ -82,7 +82,7 @@ module BloomFilter
 
     def save(filename)
       File.open(filename, 'w') do |f|
-        f << Marshal.dump(self)
+        f << Marshal.dump(self).force_encoding('UTF-8')
       end
     end
 


### PR DESCRIPTION
When using `BloomFilter::Native#save` on OS X with Ruby 1.9.3p0 I got the following error:

```

rake aborted!
"\xF8" from ASCII-8BIT to UTF-8
/Users/cbetta/.rvm/gems/ruby-1.9.3-p0@ember32/bundler/gems/bloomfilter-rb-ba20cc9eb4f2/lib/bloomfilter/native.rb:85:in `write'
/Users/cbetta/.rvm/gems/ruby-1.9.3-p0@ember32/bundler/gems/bloomfilter-rb-ba20cc9eb4f2/lib/bloomfilter/native.rb:85:in `<<'
/Users/cbetta/.rvm/gems/ruby-1.9.3-p0@ember32/bundler/gems/bloomfilter-rb-ba20cc9eb4f2/lib/bloomfilter/native.rb:85:in `block in save'
/Users/cbetta/.rvm/gems/ruby-1.9.3-p0@ember32/bundler/gems/bloomfilter-rb-ba20cc9eb4f2/lib/bloomfilter/native.rb:84:in `open'
/Users/cbetta/.rvm/gems/ruby-1.9.3-p0@ember32/bundler/gems/bloomfilter-rb-ba20cc9eb4f2/lib/bloomfilter/native.rb:84:in `save'
....
```

This patch forces the file to be encoded to UTF8
