### PR TITLE
Deserialize BloomFilter::Native properly

### DIFF
--- a/lib/bloomfilter/native.rb
+++ b/lib/bloomfilter/native.rb
@@ -70,8 +70,8 @@ module BloomFilter
     def marshal_load(ary)
       opts, bitmap = *ary
 
-      @bf = Native.new(opts)
-      @bf.bf.load(bitmap) if !bitmap.nil?
+      initialize(opts)
+      @bf.load(bitmap) if !bitmap.nil?
     end
 
     def marshal_dump

--- a/spec/native_spec.rb
+++ b/spec/native_spec.rb
@@ -133,10 +133,12 @@ describe Native do
       bf.insert('bar')
       bf.save('bf.out')
 
-      bf = Native.load('bf.out')
-      bf.include?('foo').should be_true
-      bf.include?('bar').should be_true
-      bf.include?('baz').should be_false
+      bf2 = Native.load('bf.out')
+      bf2.include?('foo').should be_true
+      bf2.include?('bar').should be_true
+      bf2.include?('baz').should be_false
+
+      bf.send(:same_parameters?, bf2).should be_true
     end
   end
 end


### PR DESCRIPTION
So you can marshal a Bloomfilter::Native. That works.
And you can unmarshal it. And that succeeds.
And then you can marshal it again. And that succeeds.
But when you unmarshal it the second time, it CRASHES HORRIBLY.

It looks like you're not restoring the @opts instance variable properly, so when it's serialized the second time, it's serialized as nil. Actually, it looks like when you're unmarshalling, you set up a Bloomfilter::Native that has its @bf variable set to another Bloomfilter::Native, instead of being a normal Bloomfilter::Native like it was before... and I guess it still superficially looks like the old one because it delegates.

(I'm writing an application which takes a bloomfilter, saves it, restores it later, updates it an hour later, and saves it again.)
