### PR TITLE
Allow the redis client instance to be passed in.

### DIFF
--- a/lib/bloomfilter/counting_redis.rb
+++ b/lib/bloomfilter/counting_redis.rb
@@ -10,7 +10,7 @@ module BloomFilter
         :ttl => false,
         :server => {}
       }.merge opts
-      @db = ::Redis.new(@opts[:server])
+      @db = @opts.delete(:db) || ::Redis.new(@opts[:server])
     end
 
     def insert(key, ttl=nil)

--- a/lib/bloomfilter/redis.rb
+++ b/lib/bloomfilter/redis.rb
@@ -10,7 +10,7 @@ module BloomFilter
         :eager  => false,
         :server => {}
       }.merge opts
-      @db = ::Redis.new(@opts[:server])
+      @db = @opts.delete(:db) || ::Redis.new(@opts[:server])
 
       if @opts[:eager]
         @db.setbit @opts[:namespace], @opts[:size]+1, 1

--- a/spec/counting_redis_spec.rb
+++ b/spec/counting_redis_spec.rb
@@ -52,5 +52,12 @@ describe CountingRedis do
     it "should connect to remote redis server" do
       lambda { CountingRedis.new }.should_not raise_error
     end
+
+    it "should allow redis client instance to be passed in" do
+      redis_client = mock Redis
+      bf = BloomFilter::CountingRedis.new(:db => redis_client)
+      bf.instance_variable_get(:@db).should be == redis_client
+    end
+
   end
 end

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -46,6 +46,12 @@ describe BloomFilter::Redis do
       lambda { BloomFilter::Redis.new }.should_not raise_error
     end
 
+    it "should allow redis client instance to be passed in" do
+      redis_client = mock ::Redis
+      bf = BloomFilter::Redis.new(:db => redis_client)
+      bf.instance_variable_get(:@db).should be == redis_client
+    end
+
     it "should allow namespaced BloomFilters" do
       bf1 = BloomFilter::Redis.new(:namespace => :a)
       bf2 = BloomFilter::Redis.new(:namespace => :b)


### PR DESCRIPTION
Saves having to rebuild the connection details hash to pass in as :server when you already have a redis instance in your ruby app. Pass in using :db option to BloomFilter::Redis.new or BloomFilter::CountingRedis.new. Falls back to previous behaviour of using `opts[:server]` to build a new redis client instance.
