### PR TITLE
Fix the pure-ruby implementation of bloom filter to work correctly.

### DIFF
--- a/examples/pure-ruby-bf.rb
+++ b/examples/pure-ruby-bf.rb
@@ -10,8 +10,8 @@ class BloomFilter
   def initialize(max_entries, num_hashes, seed)
     @num_hashes = num_hashes
     @size = max_entries.to_i
-    @bitmap = BitSet.new(@size)
-    @__mask = BitSet.new(@size)
+    @bitmap = Bitset.new(@size)
+    @__mask = Bitset.new(@size)
     @seed = seed
   end
 


### PR DESCRIPTION
The pure-ruby-bf.rb is still useful for comparison even though it is just for kicks. However, it does not work now. I have changed it as follows: 
- Fix a method call with the undefined name _new_entry?_.
- Replace the _BitSet_ class with the _Bitset_ class, which is easy to install via RubyGems.

I would appreciate it if you could merge the changes above.
