### PR TITLE
num_set methods had gone. use set_bits instead

### DIFF
--- a/lib/bloomfilter/native.rb
+++ b/lib/bloomfilter/native.rb
@@ -35,7 +35,7 @@ module BloomFilter
 
     def delete(key); @bf.delete(key); end
     def clear; @bf.clear; end
-    def size; @bf.num_set; end
+    def size; @bf.set_bits; end
     def merge!(o); @bf.merge!(o.bf); end
 
     # Returns the number of bits that are set to 1 in the filter.


### PR DESCRIPTION
In master branch, `stats` method of native filter is broken due to `num_set` method was replaced by `set_bits` by commit 808ee11bfc250.

Bug verify code and output

``` ruby
require 'bloomfilter-rb'

bf = BloomFilter::Native.new
bf.stats

# => undefined method `num_set' for #<CBloomFilter:0x00000000eaaa10> (NoMethodError)
```

so a quick fix to this problem.
