### PR TITLE
RubyInline is not actually required

### DIFF
--- a/bloomfilter-rb.gemspec
+++ b/bloomfilter-rb.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "bloomfilter-rb"
 
   s.add_dependency "redis"
-  s.add_dependency "RubyInline"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "rake-compiler" 


### PR DESCRIPTION
I've poked, prodded and tested. I can't seem to find a reason for RubyInline to be required by bloomfilter-rb. Since it makes my deployments a little more complex and strange (particularly via the related requirements it gains via RubyInline), I'd love to see it removed.
