### PR TITLE
Update to rspec 3 and modern "expect" syntax.

### DIFF
--- a/bloomfilter-rb.gemspec
+++ b/bloomfilter-rb.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "bloomfilter-rb"
 
   s.add_dependency "redis"
-  s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec", ">= 3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rake-compiler" 
 

--- a/spec/counting_redis_spec.rb
+++ b/spec/counting_redis_spec.rb
@@ -1,63 +1,61 @@
 require 'helper'
 
-include BloomFilter
+describe BloomFilter::CountingRedis do
 
-describe CountingRedis do
+  it "should connect to remote redis server" do
+    expect { BloomFilter::CountingRedis.new }.not_to raise_error
+  end
 
-  context "use Redis for storage" do
-    context "a default CountingRedis instance" do
-      let(:bf) { CountingRedis.new }
+  it "should allow redis client instance to be passed in" do
+    redis_client = double("Redis")
+    bf = BloomFilter::CountingRedis.new(:db => redis_client)
+    expect(bf.instance_variable_get(:@db)).to be(redis_client)
+  end
 
-      before do
-        # clear all redis databases
-        bf.instance_variable_get(:@db).flushall
-      end
-      
-      it "should store data in Redis" do
-        bf.insert(:abcd)
-        bf.insert('test')
-        bf.include?('test').should be_true
-        bf.key?('test').should be_true
-
-        bf.include?('test', 'test2').should be_false
-        bf.include?('test', 'abcd').should be_true
-      end
-      
-      it "should delete keys from Redis" do
-        bf.insert('test')
-        bf.include?('test').should be_true
-
-        bf.delete('test')
-        bf.include?('test').should be_false
-      end
-
-      it "should output current stats" do
-        bf.insert('test')
-        bf.size.should == 4
-        lambda { bf.stats }.should_not raise_error
-      end
+  context "a default CountingRedis instance" do
+    before do
+      # clear all redis databases
+      subject.instance_variable_get(:@db).flushall
     end
     
+    it "should store data in Redis" do
+      subject.insert(:abcd)
+      subject.insert('test')
+
+      expect(subject.include?('test')).to be true
+      expect(subject.key?('test')).to be true
+
+      expect(subject.include?('test', 'test2')).to be false
+      expect(subject.include?('test', 'abcd')).to be true
+      expect(subject.include?('test', 'abcd', 'nada')).to be false
+    end
+
+    it "should delete keys from Redis" do
+      subject.insert('test')
+      expect(subject.include?('test')).to be true
+
+      subject.delete('test')
+      expect(subject.include?('test')).to be false
+    end
+
+    it "should output current stats" do
+      subject.insert('test')
+      expect(subject.size).to eq(4)
+      expect { subject.stats }.not_to raise_error
+    end
+  end
+
+  context "a TTL 1 instance" do
+    subject { BloomFilter::CountingRedis.new(:ttl => 1) }
+
     it "should accept a TTL value for a key" do
-      bf = CountingRedis.new(:ttl => 1)
-      bf.instance_variable_get(:@db).flushall
-      
-      bf.insert('test')
-      bf.include?('test').should be_true
+      subject.instance_variable_get(:@db).flushall
+
+      subject.insert('test')
+      expect(subject.include?('test')).to be true
 
       sleep(2)
-      bf.include?('test').should be_false
+      expect(subject.include?('test')).to be false
     end
-
-    it "should connect to remote redis server" do
-      lambda { CountingRedis.new }.should_not raise_error
-    end
-
-    it "should allow redis client instance to be passed in" do
-      redis_client = mock Redis
-      bf = BloomFilter::CountingRedis.new(:db => redis_client)
-      bf.instance_variable_get(:@db).should be == redis_client
-    end
-
   end
 end

--- a/spec/native_spec.rb
+++ b/spec/native_spec.rb
@@ -1,121 +1,116 @@
 require 'helper'
 
-include BloomFilter
-
-describe Native do
+describe BloomFilter::Native do
 
   it "should clear" do
-    bf = Native.new(:size => 100, :hashes => 2, :seed => 1, :bucket => 3, :raise => false)
+    bf = BloomFilter::Native.new(:size => 100, :hashes => 2, :seed => 1, :bucket => 3, :raise => false)
     bf.insert("test")
-    bf.include?("test").should be_true
+    expect(bf.include?("test")).to be true
     bf.clear
-    bf.include?("test").should be_false
+    expect(bf.include?("test")).to be false
   end
 
   it "should merge" do
-    bf1 = Native.new(:size => 100, :hashes => 2, :seed => 1, :bucket => 3, :raise => false)
-    bf2 = Native.new(:size => 100, :hashes => 2, :seed => 1, :bucket => 3, :raise => false)
+    bf1 = BloomFilter::Native.new(:size => 100, :hashes => 2, :seed => 1, :bucket => 3, :raise => false)
+    bf2 = BloomFilter::Native.new(:size => 100, :hashes => 2, :seed => 1, :bucket => 3, :raise => false)
     bf2.insert("test")
-    bf1.include?("test").should be_false
+    expect(bf1.include?("test")).to be false
     bf1.merge!(bf2)
-    bf1.include?("test").should be_true
-    bf2.include?("test").should be_true
+    expect(bf1.include?("test")).to be true
+    expect(bf2.include?("test")).to be true
   end
 
   context "behave like a bloomfilter" do
     it "should test set membership" do
-      bf = Native.new(:size => 100, :hashes => 2, :seed => 1, :bucket => 3, :raise => false)
+      bf = BloomFilter::Native.new(:size => 100, :hashes => 2, :seed => 1, :bucket => 3, :raise => false)
       bf.insert("test")
       bf.insert("test1")
 
-      bf.include?("test").should be_true
-      bf.include?("abcd").should be_false
-      bf.include?("test", "test1").should be_true
+      expect(bf.include?("test")).to be true
+      expect(bf.include?("abcd")).to be false
+      expect(bf.include?("test", "test1")).to be true
     end
 
     it "should work with any object's to_s" do
-      bf = Native.new
-      bf.insert(:test)
-      bf.insert(:test1)
-      bf.insert(12345)
+      subject.insert(:test)
+      subject.insert(:test1)
+      subject.insert(12345)
 
-      bf.include?("test").should be_true
-      bf.include?("abcd").should be_false
-      bf.include?("test", "test1", '12345').should be_true
+      expect(subject.include?("test")).to be true
+      expect(subject.include?("abcd")).to be false
+      expect(subject.include?("test", "test1", '12345')).to be true
     end
 
     it "should return the number of bits set to 1" do
-      bf = Native.new(:hashes => 4)
+      bf = BloomFilter::Native.new(:hashes => 4)
       bf.insert("test")
-      bf.set_bits.should == 4
+      expect(bf.set_bits).to be == 4
       bf.delete("test")
-      bf.set_bits.should == 0
+      expect(bf.set_bits).to be == 0
 
-      bf = Native.new(:hashes => 1)
+      bf = BloomFilter::Native.new(:hashes => 1)
       bf.insert("test")
-      bf.set_bits.should == 1
+      expect(bf.set_bits).to be == 1
     end
 
     it "should return intersection with other filter" do
-      bf1 = Native.new(:seed => 1)
+      bf1 = BloomFilter::Native.new(:seed => 1)
       bf1.insert("test")
       bf1.insert("test1")
 
-      bf2 = Native.new(:seed => 1)
+      bf2 = BloomFilter::Native.new(:seed => 1)
       bf2.insert("test")
       bf2.insert("test2")
 
       bf3 = bf1 & bf2
-      bf3.include?("test").should be_true
-      bf3.include?("test1").should be_false
-      bf3.include?("test2").should be_false
+      expect(bf3.include?("test")).to be true
+      expect(bf3.include?("test1")).to be false
+      expect(bf3.include?("test2")).to be false
     end
 
     it "should raise an exception when intersection is to be computed for incompatible filters" do
-      bf1 = Native.new(:size => 10)
+      bf1 = BloomFilter::Native.new(:size => 10)
       bf1.insert("test")
 
-      bf2 = Native.new(:size => 20)
+      bf2 = BloomFilter::Native.new(:size => 20)
       bf2.insert("test")
 
-      proc {bf1 & bf2}.should raise_error(BloomFilter::ConfigurationMismatch)
+      expect { bf1 & bf2 }.to raise_error(BloomFilter::ConfigurationMismatch)
     end
 
     it "should return union with other filter" do
-      bf1 = Native.new(:seed => 1)
+      bf1 = BloomFilter::Native.new(:seed => 1)
       bf1.insert("test")
       bf1.insert("test1")
 
-      bf2 = Native.new(:seed => 1)
+      bf2 = BloomFilter::Native.new(:seed => 1)
       bf2.insert("test")
       bf2.insert("test2")
 
       bf3 = bf1 | bf2
-      bf3.include?("test").should be_true
-      bf3.include?("test1").should be_true
-      bf3.include?("test2").should be_true
+      expect(bf3.include?("test")).to be true
+      expect(bf3.include?("test1")).to be true
+      expect(bf3.include?("test2")).to be true
     end
 
     it "should raise an exception when union is to be computed for incompatible filters" do
-      bf1 = Native.new(:size => 10)
+      bf1 = BloomFilter::Native.new(:size => 10)
       bf1.insert("test")
 
-      bf2 = Native.new(:size => 20)
+      bf2 = BloomFilter::Native.new(:size => 20)
       bf2.insert("test")
 
-      proc {bf1 | bf2}.should raise_error(BloomFilter::ConfigurationMismatch)
+      expect {bf1 | bf2}.to raise_error(BloomFilter::ConfigurationMismatch)
     end
   end
 
   context "behave like counting bloom filter" do
     it "should delete / decrement keys" do
-      bf = Native.new
+      subject.insert("test")
+      expect(subject.include?("test")).to be true
 
-      bf.insert("test")
-      bf.include?("test").should be_true
-
-      bf.delete("test")
-      bf.include?("test").should be_false
+      subject.delete("test")
+      expect(subject.include?("test")).to be false
     end
   end
 
@@ -123,31 +118,30 @@ describe Native do
     after(:each) { File.unlink('bf.out') }
 
     it "should marshall the bloomfilter" do
-      bf = Native.new
-      lambda { bf.save('bf.out') }.should_not raise_error
+      bf = BloomFilter::Native.new
+      expect { bf.save('bf.out') }.not_to raise_error
     end
 
     it "should load marshalled bloomfilter" do
-      bf = Native.new
-      bf.insert('foo')
-      bf.insert('bar')
-      bf.save('bf.out')
+      subject.insert('foo')
+      subject.insert('bar')
+      subject.save('bf.out')
 
-      bf2 = Native.load('bf.out')
-      bf2.include?('foo').should be_true
-      bf2.include?('bar').should be_true
-      bf2.include?('baz').should be_false
+      bf2 = BloomFilter::Native.load('bf.out')
+      expect(bf2.include?('foo')).to be true
+      expect(bf2.include?('bar')).to be true
+      expect(bf2.include?('baz')).to be false
 
-      bf.send(:same_parameters?, bf2).should be_true
+      expect(subject.send(:same_parameters?, bf2)).to be true
     end
 
     it "should serialize to a file size proporational its bucket size" do
       fs_size = 0
       8.times do |i|
-        bf = Native.new(size: 10_000, bucket: i+1)
+        bf = BloomFilter::Native.new(size: 10_000, bucket: i+1)
         bf.save('bf.out')
         prev_size, fs_size = fs_size, File.size('bf.out')
-        prev_size.should < fs_size
+        expect(prev_size).to be < fs_size
       end
     end
 

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -3,53 +3,51 @@ require 'helper'
 describe BloomFilter::Redis do
 
   context "use Redis bitstring for storage" do
-    let(:bf) { BloomFilter::Redis.new }
-
     before do
       # clear all redis databases
-      bf.instance_variable_get(:@db).flushall
+      subject.instance_variable_get(:@db).flushall
     end
 
     it "should store data in Redis" do
-      bf.insert(:abcd)
-      bf.insert('test')
-      bf.include?('test').should be_true
-      bf.key?('test').should be_true
+      subject.insert(:abcd)
+      subject.insert('test')
+      expect(subject.include?('test')).to be true
+      expect(subject.key?('test')).to be true
 
-      bf.include?('test', 'test2').should be_false
-      bf.include?('test', 'abcd').should be_true
+      expect(subject.include?('test', 'test2')).to be false
+      expect(subject.include?('test', 'abcd')).to be true
     end
 
     it "should delete keys from Redis" do
-      bf.insert('test')
-      bf.include?('test').should be_true
+      subject.insert('test')
+      expect(subject.include?('test')).to be true
 
-      bf.delete('test')
-      bf.include?('test').should be_false
+      subject.delete('test')
+      expect(subject.include?('test')).to be false
     end
 
     it "should clear Redis filter" do
-      bf.insert('test')
-      bf.include?('test').should be_true
+      subject.insert('test')
+      expect(subject.include?('test')).to be true
 
-      bf.clear
-      bf.include?('test').should be_false
+      subject.clear
+      expect(subject.include?('test')).to be false
     end
 
     it "should output current stats" do
-      bf.clear
-      bf.insert('test')
-      lambda { bf.stats }.should_not raise_error
+      subject.clear
+      subject.insert('test')
+      expect { subject.stats }.not_to raise_error
     end
 
     it "should connect to remote redis server" do
-      lambda { BloomFilter::Redis.new }.should_not raise_error
+      expect { BloomFilter::Redis.new }.not_to raise_error
     end
 
     it "should allow redis client instance to be passed in" do
-      redis_client = mock ::Redis
+      redis_client = double("Redis")
       bf = BloomFilter::Redis.new(:db => redis_client)
-      bf.instance_variable_get(:@db).should be == redis_client
+      expect(bf.instance_variable_get(:@db)).to be redis_client
     end
 
     it "should allow namespaced BloomFilters" do
@@ -57,8 +55,8 @@ describe BloomFilter::Redis do
       bf2 = BloomFilter::Redis.new(:namespace => :b)
 
       bf1.insert('test')
-      bf1.include?('test').should be_true
-      bf2.include?('test').should be_false
+      expect(bf1.include?('test')).to be true
+      expect(bf2.include?('test')).to be false
     end
   end
 end


### PR DESCRIPTION
- Expect syntax is now the default in rspec, do that conversion.
- Utilize implicit subject.
- Avoid expect(x).to include(z) because it doesn't work the way we
  want for lists; stick with true/false assertions.
