### PR TITLE
Drop ignored gemspec setting rubyforge_project

### DIFF
--- a/bloomfilter-rb.gemspec
+++ b/bloomfilter-rb.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/igrigorik/bloomfilter-rb"
   s.summary     = "Counting Bloom Filter implemented in Ruby"
   s.description = s.summary
-  s.rubyforge_project = "bloomfilter-rb"
 
   s.add_development_dependency "redis"
   s.add_development_dependency "rspec", ">= 3"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436