### PR TITLE
rewrite the pure ruby example

### DIFF
--- a/examples/pure-ruby-bf.rb
+++ b/examples/pure-ruby-bf.rb
@@ -1,5 +1,5 @@
-require 'bitset' # bitset gem
-require 'zlib'   # from stdlib
+require 'bitset' # gem
+require 'zlib'   # stdlib
 
 class BloomFilter
   attr_reader :bitmap
@@ -51,7 +51,7 @@ class BloomFilter
   def to_s
     format("%i bits (%.1f kB, %i hashes) %i%% full; FPR: %.3f%%",
            @num_bits, @num_bits.to_f / 2**13, @num_hashes,
-           self.percent_full * 100, self.fpr)
+           self.percent_full * 100, self.fpr * 100)
   end
   alias_method(:inspect, :to_s)
 end
@@ -61,7 +61,7 @@ if __FILE__ == $0
   puts "Two empty lines to quit"
   puts
 
-  bf = BloomFilter.new
+  bf = BloomFilter.new(num_bits: 2**8, num_hashes: 5)
   num = 0
   last = ''
 
@@ -90,12 +90,13 @@ if __FILE__ == $0
     else
       puts format("%.1f%%\t%s", bf[str] * 100,  str)
     end
+    last = str
   end
 end
 
 
-# two newlines above should break the ingest loop
-# and we can put stuff in the test loop:
+# the two newlines above should break the ingest loop
+# and now we can put stuff in the test loop:
 if false
   puts
   # ingest loop

--- a/examples/pure-ruby-bf.rb
+++ b/examples/pure-ruby-bf.rb
@@ -95,9 +95,16 @@ if __FILE__ == $0
 end
 
 
+# Everything below this line is to enable using this source file as input:
+#   cat examples/pure-ruby-bf.rb | ruby examples/pure-ruby-bf.rb
 # the two newlines above should break the ingest loop
 # and now we can put stuff in the test loop:
 if false
+  # nothing in here will execute, but check if we've seen these lines before
+  # 1. puts (yes)
+  # 2. ingest loop comment (yes)
+  # 3. test loop comment (yes)
+  # 4. end (yes)
   puts
   # ingest loop
   # test loop

--- a/examples/pure-ruby-bf.rb
+++ b/examples/pure-ruby-bf.rb
@@ -10,22 +10,14 @@ class BloomFilter
     val = 0 # for cyclic hashing
     Array.new(num_hashes) { |i|
       case i
-      when 0
-        str.hash
-      when 1
-        Zlib.crc32(str)
-      when 2
-        Digest::MD5.hexdigest(str).to_i(16)
-      when 3
-        Digest::SHA1.hexdigest(str).to_i(16)
-      when 4
-        Digest::SHA256.hexdigest(str).to_i(16)
-      when 5
-        Digest::SHA384.hexdigest(str).to_i(16)
-      when 6
-        Digest::SHA512.hexdigest(str).to_i(16)
-      when 7
-        Digest::RMD160.hexdigest(str).to_i(16)
+      when 0 then str.hash
+      when 1 then Zlib.crc32(str)
+      when 2 then Digest::MD5.hexdigest(str).to_i(16)
+      when 3 then Digest::SHA1.hexdigest(str).to_i(16)
+      when 4 then Digest::SHA256.hexdigest(str).to_i(16)
+      when 5 then Digest::SHA384.hexdigest(str).to_i(16)
+      when 6 then Digest::SHA512.hexdigest(str).to_i(16)
+      when 7 then Digest::RMD160.hexdigest(str).to_i(16)
       else # cyclic hashing with CRC32
         val = Zlib.crc32(str, val)
       end % num_bits
@@ -84,7 +76,7 @@ if __FILE__ == $0
   puts "Two empty lines to quit"
   puts
 
-  bf = BloomFilter.new(num_bits: 384, num_hashes: 5)
+  bf = BloomFilter.new(num_bits: 512, num_hashes: 5)
   num = 0
   last = ''
 


### PR DESCRIPTION
This solves a bunch of problems while bringing additional benefits like a more standard API and modern coding practice.

Existing issues with the 12 year old version:

1. Unclear usage of Bitset.  Is it the bitset gem?  If so, the code doesn't call the Bitset API properly.
2. Unnecessary usage of bitmask, which doubles storage requirements
3. Improper use of CRC32's "seed" value: passing serial numbers (0,1,2,etc) instead of the prior hash value
4. Unnecessary use of `main()` function with somewhat confusing contents
5. Unnecessary use of seed value

I fixed all of the above, and added a bunch of features:

1. Sensible and overrideable defaults
2. Made clear that the only valid items are Strings
3. Added `BloomFilter#bits(str)` which returns an array(num_hashes) of "on bit" indices
4. Conveniently, this is exactly what the Bitset API wants
5. Hence, drastically simpler and cheaper
6. Use more standard API (for Ruby): `BloomFilter#add` and `BloomFilter#include?`
7. Added `BloomFilter#percent_full` to track status of "on bits"
8. Added `BloomFilter#fpr` to track status of false positive rate
9. Added `BloomFilter#likelihood` to return a number between 0.0 and 1.0 where 0.0 is very common and means "definitely not present"
10. `BloomFilter#to_s` to see the status of the filter
11. Added aliases to enable the following:
```
bf = BloomFilter.new
bf << 'foo'
bf['foo'] #=> 1.0 # current FPR is below epsilon
bf['bar'] #=> 0.0

bf << 'bar'
bf['bar'] #=> 1.0 # current FPR still below epsilon
bf['baz'] #=> 0.0
```
12. Aliased `#inspect` to `#to_s`
13. Rewrote `main()` to use `if __FILE__ == $0`
14. Rewrote `main()` to read from `$stdin`, such that: `cat examples/pure-ruby-bf.rb | ruby examples/pure-ruby-bf.rb` gives some useful output
15. Reading from `STDIN` is now supported properly

Note that this is based on some work I've done that will be incorporated into my compsci gem.  You may want to just point to that at some point, as I have tests and a bunch of utilities for optimal sizing, particularly for trading less hashing for slightly more bits.

As I write this commit message, I am working on integrating my main effort into the compsci repo and gem: https://github.com/rickhull/compsci

I used the 12 year old version here as a starting point, so this is my way of giving back.