### PR TITLE
pure ruby example: stop using `Digest::MD5` and friends; stop using bitset gem; add pure Ruby BitSet class

### DIFF
--- a/examples/pure-ruby-bf.rb
+++ b/examples/pure-ruby-bf.rb
@@ -114,10 +114,10 @@ if __FILE__ == $0
 
   # ingest loop
   while str = $stdin.gets&.chomp
-    if str.empty?
+    if str.empty? # display status; end the loop on consecutive empty lines
       puts bf
       break if last.empty?
-    else
+    else          # ingest the line; update the count
       bf << str
       num += 1
     end
@@ -131,10 +131,10 @@ if __FILE__ == $0
   # test loop
   last = ''
   while str = $stdin.gets&.chomp
-    if str.empty?
+    if str.empty? # as before
       puts bf
       break if last.empty?
-    else
+    else          # show the likelihood for each item and its index
       puts format("%04.1f%% %s \t %s", bf[str] * 100, str, bf.index(str))
     end
     last = str
@@ -148,10 +148,10 @@ end
 # and now we can put stuff in the test loop:
 if false
   # nothing in here will execute, but check if we've seen these lines before
-  # 1. puts (yes)
+  # 1. puts                (yes)
   # 2. ingest loop comment (yes)
-  # 3. test loop comment (yes)
-  # 4. end (yes)
+  # 3. test loop comment   (yes)
+  # 4. end                 (yes)
   puts
   # ingest loop
   # test loop


### PR DESCRIPTION
- just use CRC32
- it's fast and works very well for purpose

This PR reduces dependencies and complexity while improving performance and silencing some warnings.  It also renames "hashes" to "aspects".  Consider that a CRC is not a hash.  Anyway, if this part is controversial, I can revert / rename.