### PR TITLE
Fix #stats to prevent double formatting and use proper percent literal

### DIFF
--- a/lib/bloomfilter/filter.rb
+++ b/lib/bloomfilter/filter.rb
@@ -2,12 +2,12 @@ module BloomFilter
   class Filter
     def stats
       fp = ((1.0 - Math.exp(-(@opts[:hashes] * size).to_f / @opts[:size])) ** @opts[:hashes]) * 100
-      printf "Number of filter buckets (m): %d\n" % @opts[:size]
-      printf "Number of bits per buckets (b): %d\n" % @opts[:bucket]
-      printf "Number of filter elements (n): %d\n" % size
-      printf "Number of filter hashes (k) : %d\n" % @opts[:hashes]
-      printf "Raise on overflow? (r) : %s\n" % @opts[:raise].to_s
-      printf "Predicted false positive rate = %.2f%\n" % fp
+      printf "Number of filter buckets (m): %d\n", @opts[:size]
+      printf "Number of bits per buckets (b): %d\n", @opts[:bucket]
+      printf "Number of filter elements (n): %d\n", size
+      printf "Number of filter hashes (k) : %d\n", @opts[:hashes]
+      printf "Raise on overflow? (r) : %s\n", @opts[:raise].to_s
+      printf "Predicted false positive rate = %.2f%%\n", fp
     end
   end
 end


### PR DESCRIPTION
## What does it do?

- Fix `#stats` to prevent double formatting and use proper percent literal

## What else do you need to know?

> [!NOTE]
> 1. Ruby 4 is not as forgiving as Ruby 3 when trying to print a percent literal.
> 2. The `printf` combined with the `%` operator was double formatting the string.

----

On Ruby 4.0, the spec suite failed with:

```
Failures:

  1) BloomFilter::CountingRedis a default CountingRedis instance should output current stats
     Failure/Error: expect { subject.stats }.not_to raise_error
     
       expected no Exception, got #<ArgumentError: malformed format string> with backtrace:
         # ./lib/bloomfilter/filter.rb:10:in 'String#%'
         # ./lib/bloomfilter/filter.rb:10:in 'BloomFilter::Filter#stats'
         # ./spec/counting_redis_spec.rb:44:in 'block (4 levels) in <top (required)>'
         # ./spec/counting_redis_spec.rb:44:in 'block (3 levels) in <top (required)>'
     # ./spec/counting_redis_spec.rb:44:in 'block (3 levels) in <top (required)>'
```

## Issues

Fixes #53 

## Broken Screenshots

<img width="1384" height="464" alt="CleanShot 2026-04-01 at 08 49 10@2x" src="https://github.com/user-attachments/assets/c13f9559-7133-4625-91bb-14bc8a74c00d" />

<img width="1986" height="464" alt="CleanShot 2026-04-01 at 08 46 23@2x" src="https://github.com/user-attachments/assets/34fc26a9-305f-4a13-bbee-d6ee487ba59d" />


